### PR TITLE
adding styles for alert

### DIFF
--- a/src/components/Alert/alert.tsx
+++ b/src/components/Alert/alert.tsx
@@ -13,11 +13,6 @@ function ErrorAlert({ message, dismiss, dismissTime, type }: ErrorAlertProps) {
     const [show, setShow] = useState(true);
     const [fadeOut, setFadeOut] = useState(false);
 
-    const handleClose = () => {
-        setFadeOut(true);
-        setTimeout(() => setShow(false), 500);
-    };
-
     useEffect(() => {
         if (dismiss === "auto") {
             if (dismissTime) {
@@ -31,10 +26,48 @@ function ErrorAlert({ message, dismiss, dismissTime, type }: ErrorAlertProps) {
         }
     }, [dismiss, dismissTime]);
 
+    const handleClose = () => {
+        setFadeOut(true);
+        setTimeout(() => setShow(false), 500);
+    };
+
+    const getIcon = () => {
+        switch (type) {
+            case "Error":
+                return (
+                    <svg className="flex-shrink-0 w-5 h-5" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20">
+                        <path d="M10 0a10 10 0 1 0 10 10A10 10 0 0 0 10 0Zm1 15H9v-2h2v2Zm0-4H9V5h2v6Z" />
+                    </svg>
+                );
+            case "Success":
+                return (
+                    <svg className="flex-shrink-0 w-5 h-5" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20">
+                        <path d="M10 0a10 10 0 1 0 10 10A10 10 0 0 0 10 0Zm-1 15L4 10l1.41-1.41L9 12.17l5.59-5.59L16 8l-7 7Z" />
+                    </svg>
+                );
+            case "Info":
+                return (
+
+                    <svg className="flex-shrink-0 w-5 h-5" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20">
+                        <path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5ZM9.5 4a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3ZM12 15H8a1 1 0 0 1 0-2h1v-3H8a1 1 0 0 1 0-2h2a1 1 0 0 1 1 1v4h1a1 1 0 0 1 0 2Z" />
+                    </svg>
+                );
+            case "Warning":
+                return (
+                    <svg className="flex-shrink-0 w-5 h-5" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20">
+                        <path d="M10 0a10 10 0 1 0 10 10A10 10 0 0 0 10 0Zm1 15H9v-2h2v2Zm0-4H9V5h2v6Z" />
+                    </svg>
+                );
+            default:
+                return null;
+        }
+    };
+
+
     function closeButton() {
         return (
             <button type="button" onClick={handleClose} className={` ms-auto -mx-1.5 -my-1.5 bg-black text-green-500 rounded-lg focus:ring-2 focus:ring-green-500 p-1.5 hover:bg-green-900 inline-flex items-center justify-center h-8 w-8`} >
-                <span className="sr-only">Close</span>
+
                 <svg className="w-3 h-3" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 14">
                     <path stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="m1 1 6 6m0 0 6 6M7 7l6-6M7 7l-6 6" />
                 </svg>
@@ -45,10 +78,8 @@ function ErrorAlert({ message, dismiss, dismissTime, type }: ErrorAlertProps) {
     return (
         <>
             {show ? (
-                <div id="alert-1" className={`flex items-center p-4 mx-4 my-4 text-lg text-green-500 bg-black animate-fadeinbouncedown ${fadeOut ? 'animate-fadeoutup' : ''}`} role="alert">
-                    <svg className="flex-shrink-0 w-4 h-4" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20">
-                        <path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5ZM9.5 4a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3ZM12 15H8a1 1 0 0 1 0-2h1v-3H8a1 1 0 0 1 0-2h2a1 1 0 0 1 1 1v4h1a1 1 0 0 1 0 2Z" />
-                    </svg>
+                <div className={`flex items-center p-4 mx-4 my-4 text-lg text-green-500 bg-black animate-fadeinbouncedown ${fadeOut ? 'animate-fadeoutup' : ''}`} >
+                    {getIcon()}
 
                     <div className="ms-3 text-lg font-medium">
                         {type}: {message}
@@ -76,7 +107,7 @@ const AlertQueue = [
     },
     {
         message: "Auto Alert with no time",
-        dismiss: "auto",
+        dismiss: "manual",
         type: "Error"
     },
     {
@@ -86,12 +117,12 @@ const AlertQueue = [
     },
     {
         message: "Auto Alert with no time",
-        dismiss: "auto",
+        dismiss: "manual",
         type: "Warning"
     },
     {
         message: "Auto Alert with no time",
-        dismiss: "auto",
+        dismiss: "manual",
         type: "Success"
     },
 
@@ -102,7 +133,6 @@ const AlertQueue = [
 function Alert() {
     return (
         <>
-
             {AlertQueue.map((alert) => {
                 return <ErrorAlert message={alert.message} dismiss={alert.dismiss} dismissTime={alert.dismissTime} type={alert.type} />
             })}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 97d90947cbb5546f3dacb1b74554e1b795d46975  | 
|--------|--------|

### Summary:
Added specific icons for different alert types and updated alert queue to use manual dismiss in `src/components/Alert/alert.tsx`.

**Key points**:
- Added `getIcon` function in `src/components/Alert/alert.tsx` to return specific SVG icons for `Error`, `Success`, `Info`, and `Warning` alert types.
- Moved `handleClose` function in `src/components/Alert/alert.tsx` for better readability.
- Updated `AlertQueue` in `src/components/Alert/alert.tsx` to use manual dismiss for all alerts.
- Removed redundant SVG icon from the main alert div in `src/components/Alert/alert.tsx`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->