### PR TITLE
Parth/textinput animations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "pbmcomponents",
       "version": "0.0.0",
       "dependencies": {
+        "framer-motion": "^11.3.8",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "text-security": "^3.2.1"
@@ -6621,6 +6622,37 @@
         "type": "patreon",
         "url": "https://github.com/sponsors/rawify"
       }
+    },
+    "node_modules/framer-motion": {
+      "version": "11.3.8",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.3.8.tgz",
+      "integrity": "sha512-1D+RDTsIp4Rz2dq/oToqSEc9idEQwgBRQyBq4rGpFba+0Z+GCbj9z1s0+ikFbanWe3YJ0SqkNlDe08GcpFGj5A==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/framer-motion/node_modules/tslib": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+      "license": "0BSD"
     },
     "node_modules/fresh": {
       "version": "0.5.2",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
+    "framer-motion": "^11.3.8",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "text-security": "^3.2.1"

--- a/src/components/TextInput.tsx
+++ b/src/components/TextInput.tsx
@@ -46,7 +46,7 @@ const TextInput = ({
           onKeyDown={handleKeyDown}
           disabled={disabled}
           placeholder={placeholder}
-          className={`bg-black  w-full resize-none ${
+          className={`bg-black focus:outline-none w-full resize-none ${
             size === "single-line" ? "h-8 overflow-hidden" : "h-24"
           }
           ${censored ? "text-security" : ""}

--- a/src/components/TextInput.tsx
+++ b/src/components/TextInput.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { motion } from "framer-motion";
 
 export interface TextInputProps {
   size?: "single-line" | "multi-line";
@@ -35,11 +36,19 @@ const TextInput = ({
   };
 
   return (
-    <div className="flex flex-col text-green-500 font-mono gap-2">
-      <div className="flex flex-row p-2  border-2 border-green-500 rounded-sm relative">
-        {popover && <ToolTipGroup popover={popover} />}
+    //
 
-        <div className="px-2 ">&gt;</div>
+    <div className="flex flex-col text-green-500 font-mono gap-2">
+      <motion.div
+        className={`flex flex-row p-2 border-2 rounded-sm relative ${disabled ? "border-gray-500" : "border-green-500"} focus-within:border-green-300`}
+      >
+        {popover && <ToolTipGroup popover={popover} disabled={disabled} />}
+
+        <div
+          className={`px-2 ${disabled ? "text-gray-500" : "text-green-500"}`}
+        >
+          &gt;
+        </div>
         <textarea
           value={value}
           onChange={handleChange}
@@ -56,12 +65,12 @@ const TextInput = ({
         <button
           type="button"
           onClick={() => setValue("")}
-          className="relative ml-2 bottom-2 transform translate-y-1/2 bg-transparent border-none cursor-pointer"
+          className={`relative ml-2 bottom-2 transform translate-y-1/2 bg-transparent border-none cursor-pointer ${disabled ? "text-gray-500" : "text-green-500"}`}
           aria-label="Clear input"
         >
           x
         </button>
-      </div>
+      </motion.div>
       {valState === "error" && (
         <div className="text-red-500 text-sm">Error! {valMessage}</div>
       )}
@@ -72,10 +81,18 @@ const TextInput = ({
   );
 };
 
-const ToolTipGroup = ({ popover }: { popover: string }) => {
+const ToolTipGroup = ({
+  popover,
+  disabled,
+}: {
+  popover: string;
+  disabled: boolean;
+}) => {
   return (
     <div className="relative group">
-      <div className="border-[1px] border-green-500  px-2 text-green-500">
+      <div
+        className={`border-[1px] px-2  ${disabled ? "border-gray-500 text-gray-500" : "border-green-500 text-green-500"}`}
+      >
         i
       </div>
       <div className="absolute hidden group-hover:block bg-gray-700 text-white text-xs rounded p-1">

--- a/src/components/TextInput.tsx
+++ b/src/components/TextInput.tsx
@@ -23,6 +23,7 @@ const TextInput = ({
   valMessage,
 }: TextInputProps) => {
   const [value, setValue] = useState("");
+  const [isFocused, setIsFocused] = useState(false);
 
   const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     onChange?.(e.target.value);
@@ -40,7 +41,15 @@ const TextInput = ({
 
     <div className="flex flex-col text-green-500 font-mono gap-2">
       <motion.div
-        className={`flex flex-row p-2 border-2 rounded-sm relative ${disabled ? "border-gray-500" : "border-green-500"} focus-within:border-green-300`}
+        animate={{
+          borderColor: isFocused
+            ? "rgb(134, 239, 172)"
+            : disabled
+              ? "rgb(107, 114, 128)"
+              : "rgb(34, 197, 94)",
+        }}
+        transition={{ duration: 0.3 }}
+        className={`flex flex-row p-2 border-2 rounded-sm relative ${disabled ? "border-gray-500" : "border-green-500"} `}
       >
         {popover && <ToolTipGroup popover={popover} disabled={disabled} />}
 
@@ -51,6 +60,8 @@ const TextInput = ({
         </div>
         <textarea
           value={value}
+          onFocus={() => setIsFocused(true)}
+          onBlur={() => setIsFocused(false)}
           onChange={handleChange}
           onKeyDown={handleKeyDown}
           disabled={disabled}

--- a/src/components/TextInput.tsx
+++ b/src/components/TextInput.tsx
@@ -87,6 +87,7 @@ const TextInput = ({
             size === "single-line" ? "h-8 overflow-hidden" : "h-24"
           }
           ${censored ? "text-security" : ""}
+          ${disabled ? "text-gray-500" : "text-green-500"}
           `}
           rows={size === "single-line" ? 1 : 3}
         />

--- a/src/components/TextInput.tsx
+++ b/src/components/TextInput.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from "react";
-import { motion } from "framer-motion";
+import React, { useEffect, useState } from "react";
+import { motion, useAnimation } from "framer-motion";
 
 export interface TextInputProps {
   size?: "single-line" | "multi-line";
@@ -24,6 +24,7 @@ const TextInput = ({
 }: TextInputProps) => {
   const [value, setValue] = useState("");
   const [isFocused, setIsFocused] = useState(false);
+  const controls = useAnimation();
 
   const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     onChange?.(e.target.value);
@@ -36,19 +37,35 @@ const TextInput = ({
     }
   };
 
+  //   useEffect(() => {
+  //     if (valState === "error") {
+  //       controls.start({
+  //         x: [0, -10, 10, -10, 10, 0],
+  //         transition: { duration: 0.5 },
+  //       });
+  //     }
+  //   }, [valState, controls]);
+
+  const getBorderColor = () => {
+    if (disabled) return "rgb(107, 114, 128)"; // gray-500
+    if (valState === "error") return "rgb(239, 68, 68)"; // red-500
+    if (isFocused) return "rgb(134, 239, 172)"; // green-300
+    return "rgb(34, 197, 94)"; // green-500
+  };
+
   return (
     //
 
     <div className="flex flex-col text-green-500 font-mono gap-2">
       <motion.div
         animate={{
-          borderColor: isFocused
-            ? "rgb(134, 239, 172)"
-            : disabled
-              ? "rgb(107, 114, 128)"
-              : "rgb(34, 197, 94)",
+          borderColor: getBorderColor(),
+          x: valState === "error" ? [0, -10, 10, -10, 10, 0] : 0,
         }}
-        transition={{ duration: 0.3 }}
+        transition={{
+          borderColor: { duration: 0.3 },
+          x: { duration: 0.5, ease: "easeInOut" },
+        }}
         className={`flex flex-row p-2 border-2 rounded-sm relative ${disabled ? "border-gray-500" : "border-green-500"} `}
       >
         {popover && <ToolTipGroup popover={popover} disabled={disabled} />}


### PR DESCRIPTION
add animation
<!-- ELLIPSIS_HIDDEN -->


----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 3605c9ee743e3950262d851b6ff1a8cc308a699d  | 
|--------|--------|

### Summary:
Added animations to `TextInput` component for border color changes and error state shaking using `framer-motion`.

**Key points**:
- Added `framer-motion` dependency in `package.json`.
- Updated `src/components/TextInput.tsx` to include animations for border color changes and error state shaking.
- Introduced `useState` for `isFocused` and `useAnimation` for controlling animations.
- Modified `TextInput` component to animate border color based on focus, error, and disabled states.
- Added shaking animation for error state in `TextInput` component.
- Updated `ToolTipGroup` to handle `disabled` state for styling.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->